### PR TITLE
Upgraded tantivy to 0.19.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+/.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ keywords = ["tantivy", "jieba"]
 license = "MIT"
 
 [dependencies]
-tantivy = "0.18.0"
+tantivy = "0.19.0"
 jieba-rs = "0.6.6"
 lazy_static = "1.4.0"


### PR DESCRIPTION
To fix issues when working with the latest `tantivy 0.19.0`, need to upgrade the dependency to `tantivy 0.19.0` in this crate as well.