### PR TITLE
Support tantivy 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 [dependencies]
 jieba-rs = "0.6.7"
 lazy_static = "1.4.0"
-tantivy-tokenizer-api = "0.1.1"
+tantivy-tokenizer-api = "0.2.0"
 
 [dev-dependencies]
-tantivy = "0.20.2"
+tantivy = "0.21.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 
 use lazy_static::lazy_static;
 use tantivy_tokenizer_api::{Token, TokenStream, Tokenizer};
-use jieba_rs;
 
 lazy_static! {
     static ref JIEBA: jieba_rs::Jieba = jieba_rs::Jieba::new();
@@ -50,7 +49,7 @@ pub struct JiebaTokenStream {
 impl TokenStream for JiebaTokenStream {
     fn advance(&mut self) -> bool {
         if self.index < self.tokens.len() {
-            self.index = self.index + 1;
+            self.index += 1;
             true
         } else {
             false
@@ -69,13 +68,12 @@ impl TokenStream for JiebaTokenStream {
 impl Tokenizer for JiebaTokenizer {
     type TokenStream<'a> = JiebaTokenStream;
 
-    fn token_stream<'a>(&mut self, text: &'a str) -> JiebaTokenStream {
+    fn token_stream(&mut self, text: &str) -> JiebaTokenStream {
         let mut indices = text.char_indices().collect::<Vec<_>>();
         indices.push((text.len(), '\0'));
         let orig_tokens = JIEBA.tokenize(text, jieba_rs::TokenizeMode::Search, true);
         let mut tokens = Vec::new();
-        for i in 0..orig_tokens.len() {
-            let token = &orig_tokens[i];
+        for token in orig_tokens {
             tokens.push(Token {
                 offset_from: indices[token.start].0,
                 offset_to: indices[token.end].0,


### PR DESCRIPTION
The old version is not compatible with the new tokenizer api. Fortunately there is nothing really incompatible so the code need not to change.

I also fixed a few clippy warnings.