### PR TITLE
fix error for tantivy = "0.24.1"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 [dependencies]
 jieba-rs = "0.7.0"
 lazy_static = "1.4.0"
-tantivy-tokenizer-api = "0.3.0"
+tantivy-tokenizer-api = "0.5.0"
 
 [dev-dependencies]
-tantivy = "0.22.0"
+tantivy = "0.24.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,8 @@ impl Tokenizer for JiebaTokenizer {
 mod tests {
     #[test]
     fn it_works() {
-        use tantivy::tokenizer::*;
+        use tantivy_tokenizer_api::{TokenStream, Tokenizer};
+
         let mut tokenizer = crate::JiebaTokenizer {};
         let mut token_stream = tokenizer.token_stream(
             "张华考上了北京大学；李萍进了中等技术学校；我在百货公司当售货员：我们都有光明的前途",


### PR DESCRIPTION
https://github.com/cncases/cases/pull/104/checks

error[E0277]: the trait bound `JiebaTokenizer: Tokenizer` is not satisfied
  --> src/tantivy.rs:63:47
   |
63 |         let tokenizer = TextAnalyzer::builder(jieba_tokenizer)
   |                         --------------------- ^^^^^^^^^^^^^^^ the trait `Tokenizer` is not implemented for `JiebaTokenizer`
   |                         |
   |                         required by a bound introduced by this call
   |
note: there are multiple different versions of crate `tantivy_tokenizer_api` in the dependency graph
  --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tantivy-tokenizer-api-0.5.0/src/lib.rs:56:1
   |
56 | pub trait Tokenizer: 'static + Clone + Send + Sync {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this is the required trait
   |
  ::: src/lib.rs:8:5
   |
8  | use tantivy::Searcher;
   |     ------- one version of crate `tantivy_tokenizer_api` used here, as a dependency of crate `tantivy`
   |
  ::: src/tantivy.rs:62:31
   |
62 |         let jieba_tokenizer = tantivy_jieba::JiebaTokenizer {};
   |                               ------------- one version of crate `tantivy_tokenizer_api` used here, as a dependency of crate `tantivy_jieba`
   |
  ::: /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tantivy-jieba-0.11.0/src/lib.rs:39:1
   |
39 | pub struct JiebaTokenizer;
   | ------------------------- this type doesn't implement the required trait
   |
  ::: /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tantivy-tokenizer-api-0.3.0/src/lib.rs:56:1
   |
56 | pub trait Tokenizer: 'static + Clone + Send + Sync {
   | -------------------------------------------------- this is the found trait
   = help: you can use `cargo tree` to explore your dependency tree
note: required by a bound in `TextAnalyzer::builder`
  --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tantivy-0.24.1/src/tokenizer/tokenizer.rs:63:23
   |
63 |     pub fn builder<T: Tokenizer>(tokenizer: T) -> TextAnalyzerBuilder<T> {
   |                       ^^^^^^^^^ required by this bound in `TextAnalyzer::builder`

error[E0599]: the method `filter` exists for struct `TextAnalyzerBuilder<JiebaTokenizer>`, but its trait bounds were not satisfied
  --> src/tantivy.rs:64:14
   |
63 |           let tokenizer = TextAnalyzer::builder(jieba_tokenizer)
   |  _________________________-
64 | |             .filter(StopWordFilter::remove(custom_stop_words))
   | |             -^^^^^^ method cannot be called on `TextAnalyzerBuilder<JiebaTokenizer>` due to unsatisfied trait bounds
   | |_____________|
   |
   |
  ::: /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tantivy-jieba-0.11.0/src/lib.rs:39:1
   |
39 |   pub struct JiebaTokenizer;
   |   ------------------------- doesn't satisfy `JiebaTokenizer: Tokenizer`
   |
  ::: /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tantivy-0.24.1/src/tokenizer/tokenizer.rs:74:1
   |
74 |   pub struct TextAnalyzerBuilder<T = Box<dyn BoxableTokenizer>> {
   |   ------------------------------------------------------------- doesn't satisfy `TextAnalyzerBuilder<JiebaTokenizer>: Iterator`
   |
   = note: the following trait bounds were not satisfied:
           `JiebaTokenizer: Tokenizer`
           `TextAnalyzerBuilder<JiebaTokenizer>: Iterator`
           which is required by `&mut TextAnalyzerBuilder<JiebaTokenizer>: Iterator`

Some errors have detailed explanations: E0277, E0599.
For more information about an error, try `rustc --explain E0277`.
error: could not compile `cases` (lib) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
Error: Process completed with exit code 101.

