### PR TITLE
fix token position

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,10 +117,6 @@ mod tests {
         assert_eq!(tokens[0].offset_from, 0);
         assert_eq!(tokens[0].offset_to, "张华".len());
         assert_eq!(tokens[1].offset_from, "张华".len());
-        // check position
-        for (i, token) in tokens.iter().enumerate() {
-            assert_eq!(token.position, i);
-        }
         // check tokenized text
         assert_eq!(
             token_text,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,8 @@ impl TokenStream for JiebaTokenStream<'_> {
         let jieba_token = &self.jieba_tokens[self.index];
         self.token.offset_from = jieba_token.word.as_ptr() as usize - self.text.as_ptr() as usize;
         self.token.offset_to = self.token.offset_from + jieba_token.word.len();
-        self.token.position = self.index;
+        self.token.position = jieba_token.start;
+        self.token.position_length = jieba_token.end - jieba_token.start;
         self.token.text.clear(); // avoid realloc
         self.token.text.push_str(jieba_token.word);
         self.index += 1;
@@ -82,9 +83,9 @@ impl Tokenizer for JiebaTokenizer {
             .map(|token| Token {
                 offset_from: token.word.as_ptr() as usize - text.as_ptr() as usize,
                 offset_to: token.word.as_ptr() as usize - text.as_ptr() as usize + token.word.len(),
-                position: 0,
                 text: token.word.to_string(),
-                position_length: 1,
+                position: token.start,
+                position_length: token.end - token.start,
             })
             .unwrap_or_default();
         JiebaTokenStream {

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -1,0 +1,64 @@
+//! Integration test for tantivy-jieba
+
+use tantivy::collector::Count;
+use tantivy::doc;
+use tantivy::query::QueryParser;
+use tantivy::schema::*;
+use tantivy::tokenizer::*;
+use tantivy::Index;
+
+#[test]
+fn search() {
+    // Build schema
+    let mut schema_builder = Schema::builder();
+    let name = schema_builder.add_text_field(
+        "name",
+        TextOptions::default()
+            .set_indexing_options(
+                TextFieldIndexing::default()
+                    .set_tokenizer("jieba")
+                    .set_index_option(IndexRecordOption::WithFreqsAndPositions),
+            )
+            .set_stored(),
+    );
+    let schema = schema_builder.build();
+
+    // Register tantivy tokenizer
+    let tokenizer = tantivy_jieba::JiebaTokenizer {};
+    let index = Index::create_in_ram(schema);
+    let analyzer = TextAnalyzer::builder(tokenizer)
+        .filter(RemoveLongFilter::limit(40))
+        .filter(LowerCaser)
+        .filter(Stemmer::default())
+        .build();
+    index.tokenizers().register("jieba", analyzer);
+
+    // Index some documents
+    let mut index_writer = index.writer(50_000_000).unwrap();
+    index_writer
+        .add_document(doc!(name => "中华人民共和国人民大会堂"))
+        .unwrap();
+    index_writer.commit().unwrap();
+
+    // Search keywords
+    let reader = index.reader().unwrap();
+    let searcher = reader.searcher();
+    let query_parser = QueryParser::for_index(&index, vec![name]);
+
+    for query_str in [
+        "中华",
+        "人民",
+        "共和国",
+        "华人",
+        "共和",
+        "人民共和",
+        "中华人民共和国",
+        "共和国人民",
+        "人民大会堂",
+    ] {
+        let query = query_parser.parse_query(query_str).unwrap();
+        println!("query: {query:?}");
+        let count = searcher.search(&query, &Count).unwrap();
+        assert_eq!(count, 1, "doc not found for query: {query_str}");
+    }
+}


### PR DESCRIPTION
This PR reverts https://github.com/jiegec/tantivy-jieba/pull/15. Since the jieba search mode may output 2-gram and 3-gram substrings of a long term, using token indices as token positions could prevent some phrases from being searched. Therefore, we have reverted the token position to Unicode indices. This PR also adds a tantivy integration test to ensure phrases can be searched.