### PR TITLE
merge CustomJiebaTokenizer into JiebaTokenizer and add options for search mode

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,5 +1,6 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use std::fs;
+use std::hint::black_box;
 use tantivy_jieba::JiebaTokenizer;
 use tantivy_tokenizer_api::{TokenStream, Tokenizer};
 
@@ -15,7 +16,7 @@ fn jieba_tokenizer_benchmark(c: &mut Criterion) {
     group.throughput(Throughput::Bytes(text_bytes));
     group.bench_function("tokenize", |b| {
         b.iter(|| {
-            let mut tokenizer = JiebaTokenizer;
+            let mut tokenizer = JiebaTokenizer::new();
             let mut token_stream = tokenizer.token_stream(black_box(&text));
             while token_stream.advance() {
                 black_box(token_stream.token());

--- a/examples/mod.rs
+++ b/examples/mod.rs
@@ -22,7 +22,7 @@ fn main() {
     let schema = schema_builder.build();
 
     // Register tantivy tokenizer
-    let tokenizer = tantivy_jieba::JiebaTokenizer {};
+    let tokenizer = tantivy_jieba::JiebaTokenizer::new();
     let index = Index::create_in_ram(schema);
     let analyzer = TextAnalyzer::builder(tokenizer)
         .filter(RemoveLongFilter::limit(40))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,17 @@ lazy_static! {
 /// assert!(token_stream.next().is_none());
 /// ```
 ///
+/// ## With custom jieba instance
+///
+/// ```rust
+/// use tantivy::tokenizer::*;
+/// let mut jieba = jieba_rs::Jieba::new();
+/// let mut tokenizer = tantivy_jieba::JiebaTokenizer::with_jieba(jieba);
+/// let mut token_stream = tokenizer.token_stream("测试");
+/// assert_eq!(token_stream.next().unwrap().text, "测试");
+/// assert!(token_stream.next().is_none());
+/// ```
+///
 /// ## Register as tantivy tokenizer
 ///
 /// ```rust
@@ -37,7 +48,7 @@ lazy_static! {
 /// use tantivy::tokenizer::*;
 /// use tantivy::Index;
 /// # let schema = Schema::builder().build();
-/// let tokenizer = tantivy_jieba::JiebaTokenizer {};
+/// let tokenizer = tantivy_jieba::JiebaTokenizer::new();
 /// let index = Index::create_in_ram(schema);
 /// index.tokenizers()
 ///      .register("jieba", tokenizer);
@@ -45,17 +56,33 @@ lazy_static! {
 pub struct JiebaTokenizer {
     /// Whether to use search mode for tokenization
     search_mode: bool,
+    /// Optional custom jieba instance, uses global instance if None
+    jieba: Option<jieba_rs::Jieba>,
 }
 
 impl JiebaTokenizer {
-    /// Create a new JiebaTokenizer with search mode enabled by default
+    /// Create a new JiebaTokenizer
     pub fn new() -> Self {
-        Self { search_mode: true }
+        Self {
+            search_mode: true,
+            jieba: None,
+        }
     }
 
     /// Create a new JiebaTokenizer with specified search mode
     pub fn with_search_mode(search_mode: bool) -> Self {
-        Self { search_mode }
+        Self {
+            search_mode,
+            jieba: None,
+        }
+    }
+
+    /// Create a new JiebaTokenizer with custom jieba instance
+    pub fn with_jieba(jieba: jieba_rs::Jieba) -> Self {
+        Self {
+            search_mode: true,
+            jieba: Some(jieba),
+        }
     }
 
     /// Get the current search mode setting
@@ -66,6 +93,17 @@ impl JiebaTokenizer {
     /// Set the search mode
     pub fn set_search_mode(&mut self, search_mode: bool) {
         self.search_mode = search_mode;
+    }
+
+    /// Set a custom jieba instance
+    pub fn set_jieba(&mut self, jieba: jieba_rs::Jieba) {
+        self.jieba = Some(jieba);
+    }
+
+    /// Extract the [`Jieba`](jieba_rs::Jieba) instance and drop self.
+    /// Returns None if using global jieba instance.
+    pub fn into_jieba(self) -> Option<jieba_rs::Jieba> {
+        self.jieba
     }
 }
 
@@ -79,63 +117,16 @@ impl Tokenizer for JiebaTokenizer {
     type TokenStream<'str> = JiebaTokenStream<'str>;
 
     fn token_stream<'str>(&mut self, text: &'str str) -> JiebaTokenStream<'str> {
-        token_stream_common(&JIEBA, text, self.search_mode)
+        match &self.jieba {
+            Some(custom_jieba) => token_stream_common(custom_jieba, text, self.search_mode),
+            None => token_stream_common(&JIEBA, text, self.search_mode),
+        }
     }
 }
 
-/// Tokenize the text using jieba_rs with custom [`Jieba`](jieba_rs::Jieba) instance.
+/// Token stream instantiated by [`JiebaTokenizer`](JiebaTokenizer).
 ///
-/// Need to load dict on first tokenization.
-///
-/// # Examples
-///
-/// ```rust
-/// use tantivy::tokenizer::*;
-/// let mut jieba = jieba_rs::Jieba::new();
-/// let mut tokenizer = tantivy_jieba::CustomJiebaTokenizer::new(jieba);
-/// let mut token_stream = tokenizer.token_stream("测试");
-/// assert_eq!(token_stream.next().unwrap().text, "测试");
-/// assert!(token_stream.next().is_none());
-/// ```
-#[derive(Clone)]
-pub struct CustomJiebaTokenizer {
-    jieba: jieba_rs::Jieba,
-}
-
-impl CustomJiebaTokenizer {
-    /// Create a new [`CustomJiebaTokenizer`](CustomJiebaTokenizer) instance using the given [`Jieba`](jieba_rs::Jieba) instance.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tantivy::tokenizer::*;
-    /// let mut jieba = jieba_rs::Jieba::new();
-    /// let mut tokenizer = tantivy_jieba::CustomJiebaTokenizer::new(jieba);
-    /// let mut token_stream = tokenizer.token_stream("测试");
-    /// assert_eq!(token_stream.next().unwrap().text, "测试");
-    /// assert!(token_stream.next().is_none());
-    /// ```
-    pub fn new(jieba: jieba_rs::Jieba) -> Self {
-        Self { jieba }
-    }
-
-    /// Extract the [`Jieba`](jieba_rs::Jieba) instance and drop self.
-    pub fn into_jieba(self) -> jieba_rs::Jieba {
-        self.jieba
-    }
-}
-
-impl Tokenizer for CustomJiebaTokenizer {
-    type TokenStream<'str> = JiebaTokenStream<'str>;
-
-    fn token_stream<'str>(&mut self, text: &'str str) -> JiebaTokenStream<'str> {
-        token_stream_common(&self.jieba, text, true)
-    }
-}
-
-/// Token stream instantiated by [`JiebaTokenizer`](JiebaTokenizer) or [`CustomJiebaTokenizer`](CustomJiebaTokenizer).
-///
-/// Use [`JiebaTokenizer::token_stream`](JiebaTokenizer::token_stream) or [`CustomJiebaTokenizer::token_stream`](CustomJiebaTokenizer::token_stream).
+/// Use [`JiebaTokenizer::token_stream`](JiebaTokenizer::token_stream).
 pub struct JiebaTokenStream<'str> {
     text: &'str str,
     jieba_tokens: Vec<jieba_rs::Token<'str>>,
@@ -169,7 +160,11 @@ impl TokenStream for JiebaTokenStream<'_> {
 }
 
 /// Create token stream from text
-fn token_stream_common<'str>(jieba: &jieba_rs::Jieba, text: &'str str, search_mode: bool) -> JiebaTokenStream<'str> {
+fn token_stream_common<'str>(
+    jieba: &jieba_rs::Jieba,
+    text: &'str str,
+    search_mode: bool,
+) -> JiebaTokenStream<'str> {
     let mode = if search_mode {
         jieba_rs::TokenizeMode::Search
     } else {

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -24,7 +24,7 @@ fn search() {
     let schema = schema_builder.build();
 
     // Register tantivy tokenizer
-    let tokenizer = tantivy_jieba::JiebaTokenizer {};
+    let tokenizer = tantivy_jieba::JiebaTokenizer::new();
     let index = Index::create_in_ram(schema);
     let analyzer = TextAnalyzer::builder(tokenizer)
         .filter(RemoveLongFilter::limit(40))


### PR DESCRIPTION
This PR merges the functionality of CustomJiebaTokenizer into the main JiebaTokenizer struct. It also adds an options to disable search mode.