### PR TITLE
chore: bump up jieba-rs version make it faster

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["tantivy", "jieba"]
 license = "MIT"
 
 [dependencies]
-jieba-rs = "0.8.0"
+jieba-rs = "0.10.0"
 lazy_static = "1.4.0"
 tantivy-tokenizer-api = "0.7.0"
 


### PR DESCRIPTION
this patch bump jieba-rs version which is more faster 

more to see:

 - https://messense.me/making-jieba-rs-2-4x-faster-zh-cn
 - and patch https://github.com/messense/jieba-rs/pull/147

| source | short sentence x100000 | whole `weicheng.txt` | line-by-line `weicheng.txt` |
| --- | ---: | ---: | ---: |
| `jieba-rs 0.8.1` | `394.615709 ms` | `36.020167 ms` | `32.372834 ms` |
| crates.io `jieba-rs 0.9.0` | `342.159291 ms` | `1.600094625 s` | `130.526459 ms` |
| patched local change | `262.749834 ms` | `26.455667 ms` | `26.3505 ms` |
